### PR TITLE
alias aarch64 to arm64

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -130,6 +130,8 @@ detect_arch() {
       arch=x86
     elif [ "${arch}" = "x86_64" ]; then
       arch=x64
+    elif [ "${arch}" = "aarch64" ]; then
+      arch=arm64
     fi
 
     # `uname -m` in some cases mis-reports 32-bit OS as 64-bit, so double check


### PR DESCRIPTION
Currently, the install script fails on my raspberry pi4. `uname -m` returns `aarch64`, which is the same thing as `arm64`. Adding this if statement resolves my issues:

```
elif [ "${arch}" = "aarch64" ]; then
      arch=arm64
```

**Master branch install result:**

```
ubuntu% curl -sL install-node.now.sh/lts | bash
  Configuration
> Version:  v14.15.4 (resolved from lts)
> Prefix:   /usr/local
> Platform: linux
> Arch:     aarch64

> Tarball URL: https://nodejs.org/dist/v14.15.4/node-v14.15.4-linux-aarch64.tar.gz
? Install Node.js v14.15.4 to /usr/local? [yN] y
> Installing Node.js, please wait…
x Command failed (exit code 22): curl --silent --fail https://nodejs.org/dist/v14.15.4/node-v14.15.4-linux-aarch64.tar.gz

gzip: stdin: unexpected end of file
tar: Child returned status 1
tar: Error is not recoverable: exiting now
```

**My fork install result:**

```
ubuntu% curl -sL https://raw.githubusercontent.com/jrodal98/install-node/master/install.sh | bash
  Configuration
> Version:  v15.6.0 (resolved from latest)
> Prefix:   /usr/local
> Platform: linux
> Arch:     arm64

> Tarball URL: https://nodejs.org/dist/v15.6.0/node-v15.6.0-linux-arm64.tar.gz
? Install Node.js v15.6.0 to /usr/local? [yN] y
> Installing Node.js, please wait…
✓ Done
```