### PR TITLE
fix: Use new domain

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,4 @@
-# install-node.now.sh
+# install-node.vercel.app
 
 Simple one-liner shell script that installs official Node.js binaries
 
@@ -7,5 +7,5 @@ Simple one-liner shell script that installs official Node.js binaries
 Create `install-node` as an alias!
 
 ```bash
-alias install-node="curl -s https://install-node.now.sh | bash -s --"
+alias install-node="curl -s https://install-node.vercel.app | bash -s --"
 ```

--- a/install.sh
+++ b/install.sh
@@ -1,31 +1,31 @@
 #!/bin/bash
-# `install-node.now.sh` is a simple one-liner shell script to
+# `install-node.vercel.app` is a simple one-liner shell script to
 # install official Node.js binaries from `nodejs.org/dist` or other
 # blessed sources (i.e. Alpine Linux builds are not on nodejs.org)
 #
 # For newest Node.js version:
 #
-#   $ curl -sL install-node.now.sh | sh
+#   $ curl -sL install-node.vercel.app | sh
 
 # For latest LTS Node.js version:
 #
-#   $ curl -sL install-node.now.sh/lts | sh
+#   $ curl -sL install-node.vercel.app/lts | sh
 #
 # Install a specific version (ex: v8.9.0):
 #
-#   $ curl -sL install-node.now.sh/v8.9.0 | sh
+#   $ curl -sL install-node.vercel.app/v8.9.0 | sh
 #
 # Semver also works (ex: v4.x.x):
 #
-#   $ curl -sL install-node.now.sh/4 | sh
+#   $ curl -sL install-node.vercel.app/4 | sh
 #
 # Options may be passed to the shell script with `-s --`:
 #
-#   $ curl -sL install-node.now.sh | sh -s -- --prefix=$HOME --version=8 --verbose
-#   $ curl -sL install-node.now.sh | sh -s -- -P $HOME -v 8 -V
+#   $ curl -sL install-node.vercel.app | sh -s -- --prefix=$HOME --version=8 --verbose
+#   $ curl -sL install-node.vercel.app | sh -s -- -P $HOME -v 8 -V
 #
 # Patches welcome!
-# https://github.com/zeit/install-node.now.sh
+# https://github.com/zeit/install-node.vercel.app
 # Nathan Rajlich <nate@zeit.co>
 set -euo pipefail
 
@@ -88,7 +88,7 @@ resolve_node_version() {
   if [ "${tag}" = "latest" ]; then
     tag=
   fi
-  fetch "https://resolve-node.now.sh/$tag"
+  fetch "https://resolve-node.vercel.app/$tag"
 }
 
 # Currently known to support:


### PR DESCRIPTION
# Why
- `(install|resolve)-node.now.sh` is now redirect to `(install|resolve)-node.vercel.app` 
- The redirect breaks install process now.
  - ec) resolve-node returns `Redirecting to https://resolve-node.vercel.app/14.16.0 (308)` and use it as version X(

# What
- Use new domain.

# Disscuss
- Can you revert redirecting from `now.sh` to `vercel.app` ?